### PR TITLE
adding also the proxy when using the repo

### DIFF
--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -18,6 +18,7 @@
     name: jenkinsrepo
     description: Jenkins YUM Repository
     baseurl: http://pkg.jenkins.io/redhat
+    proxy: "{{ jenkins2_rpm_key_proxy_url }}"
     gpgcheck: yes
     state: present
   become: yes


### PR DESCRIPTION
Hello, 
Setting the **proxy in the jenkinsrepo** was pertinent for me.

I guess it's the same for the others users who are forced to use proxy.
(Thanks you for this ansible role, very useful and easily working.)

Cedric
